### PR TITLE
V3: Fix click to close in handleEvents

### DIFF
--- a/src/toastr.js
+++ b/src/toastr.js
@@ -382,11 +382,11 @@ class toastr {
             toastElement.addEventListener('mouseout', delayedHideToast);
 
             if (!options.onclick && options.tapToDismiss) {
-                toastElement.click(hideToast);
+                toastElement.addEventListener('click', hideToast);
             }
 
             if (options.closeButton && closeElement) {
-                closeElement.click(function (event) {
+                closeElement.addEventListener('click', function (event) {
                     if (event.stopPropagation) {
                         event.stopPropagation();
                     } else if (event.cancelBubble !== undefined && event.cancelBubble !== true) {
@@ -397,7 +397,7 @@ class toastr {
             }
 
             if (options.onclick) {
-                toastElement.click(function () {
+                toastElement.addEventListener('click', function () {
                     options.onclick(); // TODO remove jQuery
                     hideToast();
                 });


### PR DESCRIPTION
Hi,
I was looking for bugs in the v3-branch, when i noticed that I could not close a notification by clicking on it.
The cause seems to be the usage of the .click(handler) in handleEvents. In vanilla JS, the correct way to bind to the click event is by using addEventListener.
